### PR TITLE
Normaliza cabeçalhos de licença GPL nos arquivos do plugin

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Formulário de configuração das atividades dos relatórios.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 require_once("$CFG->libdir/formslib.php");
 

--- a/config_form.php
+++ b/config_form.php
@@ -18,7 +18,7 @@
  * Formulário de configuração das atividades dos relatórios.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/access.php
+++ b/db/access.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definição das capabilities do plugin local_report_config.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/db/access.php
+++ b/db/access.php
@@ -18,7 +18,7 @@
  * Definição das capabilities do plugin local_report_config.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -15,6 +15,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Rotinas de atualização do esquema do plugin local_report_config.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
 function xmldb_local_report_config_upgrade($oldversion) {
     global $CFG, $DB, $OUTPUT;
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -19,7 +19,7 @@
  * Rotinas de atualização do esquema do plugin local_report_config.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/edit.php
+++ b/edit.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Página de edição da configuração de relatórios da categoria.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 require_once('../../config.php');
 require_once($CFG->libdir . '/adminlib.php');

--- a/edit.php
+++ b/edit.php
@@ -18,7 +18,7 @@
  * Página de edição da configuração de relatórios da categoria.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
  * Página inicial da configuração de relatórios da categoria.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/index.php
+++ b/index.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Página inicial da configuração de relatórios da categoria.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 require_once($CFG->dirroot . '/config.php');
 require_once($CFG->libdir . '/adminlib.php');

--- a/lang/en/local_report_config.php
+++ b/lang/en/local_report_config.php
@@ -18,7 +18,7 @@
  * Strings de idioma (en) do plugin local_report_config.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/lang/en/local_report_config.php
+++ b/lang/en/local_report_config.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings de idioma (en) do plugin local_report_config.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 $string['reportconfig'] = 'Configuração Relatórios';
 $string['pluginname'] = 'Configuração Relatórios';

--- a/lib.php
+++ b/lib.php
@@ -18,7 +18,7 @@
  * Funções de biblioteca e extensão de navegação do plugin local_report_config.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/lib.php
+++ b/lib.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Funções de biblioteca e extensão de navegação do plugin local_report_config.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/locallib.php
+++ b/locallib.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Funções internas de montagem da lista de atividades por curso/categoria.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/locallib.php
+++ b/locallib.php
@@ -18,7 +18,7 @@
  * Funções internas de montagem da lista de atividades por curso/categoria.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/renderer.php
+++ b/renderer.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Renderer do plugin local_report_config.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/renderer.php
+++ b/renderer.php
@@ -18,7 +18,7 @@
  * Renderer do plugin local_report_config.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/version.php
+++ b/version.php
@@ -18,7 +18,7 @@
  * Metadados de versão do plugin local_report_config.
  *
  * @package    local_report_config
- * @copyright  2022 UFSC
+ * @copyright  2026 UFSC
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 

--- a/version.php
+++ b/version.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Metadados de versão do plugin local_report_config.
+ *
+ * @package    local_report_config
+ * @copyright  2022 UFSC
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 defined('MOODLE_INTERNAL') || die();
 


### PR DESCRIPTION
## Resumo

Normaliza os cabeçalhos dos arquivos do plugin `local_report_config`, adicionando o bloco de licença GPL e o docblock de arquivo (`@package` / `@copyright` / `@license`) onde faltava. Objetivo: conformidade com o `moodlecheck`/codechecker e uniformidade com o `db/upgrade.php`, que já trazia o bloco de licença.

## Arquivos (10)
- `config_form.php`, `edit.php`, `index.php` — entry points (sem `defined('MOODLE_INTERNAL')`, pois carregam o `config.php`).
- `lib.php`, `locallib.php`, `renderer.php`, `version.php`, `db/access.php` — bloco GPL + docblock antes do `defined('MOODLE_INTERNAL') || die();`.
- `db/upgrade.php` — já tinha o bloco GPL; adicionado o docblock e o `defined('MOODLE_INTERNAL')`.
- `lang/en/local_report_config.php` — bloco GPL + docblock, sem `defined()` (convenção de arquivos de idioma).

## Risco
- **Nenhuma mudança de comportamento**: apenas comentários (e o guard padrão `defined('MOODLE_INTERNAL')` no `upgrade.php`). Todos os 10 arquivos passam em `php -l`.
- Independente do PR #2 (testes): parte da `master`, sem sobreposição de arquivos.

## Nota
Copyright definido como `2026 UFSC` (institucional), consistente com os arquivos de teste do PR #2. Ajustável se preferirem outra atribuição/ano.