### PR TITLE
Adiciona docblocks de classe/função

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -42,10 +42,19 @@ $PAGE->set_heading(get_string('pluginname', 'local_report_config'));
 
 require_login();
 
+/**
+ * Formulário com um checkbox por atividade configurável da categoria.
+ */
 class Config_form extends moodleform {
 
+    /** @var array Mapa [course_id][module_id][activity_id] => nome do checkbox. */
     private $dados = array();
 
+    /**
+     * Define os campos do formulário a partir das atividades da categoria.
+     *
+     * @return void
+     */
     public function definition() {
 
         global $DB;
@@ -110,6 +119,11 @@ class Config_form extends moodleform {
         $this->add_action_buttons();
     }
 
+    /**
+     * Devolve o mapa [course_id][module_id][activity_id] => nome do checkbox.
+     *
+     * @return array
+     */
     function get_dados() {
         return $this->dados;
     }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -25,6 +25,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * Atualiza o esquema do plugin entre versões.
+ *
+ * @param int $oldversion versão instalada antes da atualização
+ * @return bool
+ */
 function xmldb_local_report_config_upgrade($oldversion) {
     global $CFG, $DB, $OUTPUT;
 

--- a/lib.php
+++ b/lib.php
@@ -26,6 +26,15 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/local/report_config/locallib.php');
 
+/**
+ * Adiciona o link de configuração de relatórios às configurações da categoria.
+ *
+ * Só inclui o nó quando o contexto é de categoria, o usuário tem a capability
+ * local/report_config:manage e a categoria possui ao menos um curso.
+ *
+ * @param navigation_node $navigation nó de navegação da página atual
+ * @return void
+ */
 function local_report_config_extend_settings_navigation(navigation_node $navigation) {
     global $PAGE, $DB;
 
@@ -65,11 +74,25 @@ function local_report_config_extend_settings_navigation(navigation_node $navigat
     }
 }
 
+/**
+ * Monta e persiste a configuração das atividades exibidas nos relatórios.
+ *
+ * A partir dos dados do formulário, determina quais atividades foram desmarcadas
+ * e grava esse conjunto em activities_course_config.
+ */
 class Config {
 
-    public $config_report; //Array com os dados de configuração
+    /** @var array Atividades desmarcadas, agrupadas por curso e módulo. */
+    public $config_report;
+
+    /** @var int Id da categoria sendo configurada. */
     public $categoryid;
 
+    /**
+     * @param array $dados árvore [course_id][module_id][activity_id] => nome do checkbox
+     * @param stdClass $fromform dados retornados por moodleform::get_data()
+     * @param int $categoryid id da categoria sendo configurada
+     */
     function __construct($dados, $fromform, $categoryid) {
 
         //Transformação de um objeto e seus respectivos atributos em um array
@@ -102,15 +125,23 @@ class Config {
         $this->categoryid = $categoryid;
     }
 
+    /**
+     * Devolve as atividades desmarcadas, agrupadas por curso e módulo.
+     *
+     * @return array
+     */
     function get_config_report() {
         return $this->config_report;
     }
 
-    /*
-     * Função executada após clicar no botão de Salvar do formulário (onde cria-se uma nova configuração)
-     * de configuração de relatórios.
-     * Seu funcionamento é deletar todas as entradas na tabela e adicionar as entradas do array $config_report que foi
-     * contruído durante a execução desta classe. Este array guarda as atividades não checadas do formulário.
+    /**
+     * Regrava activities_course_config para a categoria.
+     *
+     * Apaga todas as entradas da categoria e insere uma para cada atividade
+     * desmarcada (o conjunto montado no construtor) — são as atividades ocultadas
+     * dos relatórios.
+     *
+     * @return void
      */
     function add_or_update_config_report() {
         global $DB;

--- a/locallib.php
+++ b/locallib.php
@@ -27,6 +27,12 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/moodlelib.php');
 require_once($CFG->dirroot . '/report/unasus/locallib.php');
 
+/**
+ * Lista as atividades dos cursos da categoria agrupadas por tipo de módulo.
+ *
+ * @param int|null $categoryid id da categoria; quando null, lê de required_param
+ * @return array [course_id => lista de objetos report_unasus_*_activity_report_config]
+ */
 function get_activities_courses($categoryid = null) {
 
     $categoryid = $categoryid == null ? required_param('categoryid', PARAM_INT) : $categoryid;
@@ -84,6 +90,12 @@ function get_activities_courses($categoryid = null) {
     return $group_array->get_assoc();
 }
 
+/**
+ * Lista as atividades dos cursos da categoria na ordem de apresentação.
+ *
+ * @param int|null $categoryid id da categoria; quando null, lê de required_param
+ * @return array [course_id => lista de report_unasus_generic_activity_report_config]
+ */
 function get_ordered_courses_activities($categoryid = null) {
 
     $categoryid = $categoryid == null ? required_param('categoryid', PARAM_INT) : $categoryid;
@@ -115,6 +127,13 @@ function get_ordered_courses_activities($categoryid = null) {
     return $group_array->get_assoc();
 }
 
+/**
+ * Devolve os cursos (módulos) da categoria, separando os de nível raiz dos
+ * agrupados em subcategorias.
+ *
+ * @param int $categoria_curso id da categoria
+ * @return array
+ */
 function get_name_modulos($categoria_curso) {
     $modulos = report_unasus_get_id_nome_modulos($categoria_curso, 'get_records_sql', false);
 

--- a/renderer.php
+++ b/renderer.php
@@ -24,9 +24,19 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * Renderiza o cabeçalho e o rodapé das páginas de configuração de relatórios.
+ */
 class local_report_config_renderer extends plugin_renderer_base
 {
 
+    /** @var int Id da categoria sendo renderizada. */
+    public $categoryid;
+
+    /**
+     * @param moodle_page $page página em renderização
+     * @param string $target alvo de renderização (ver rendererfactory)
+     */
     public function __construct(moodle_page $page, $target)
     {
         parent::__construct($page, $target);
@@ -34,6 +44,11 @@ class local_report_config_renderer extends plugin_renderer_base
         $this->categoryid = required_param('categoryid', PARAM_INT);
     }
 
+    /**
+     * Cabeçalho da página, com título e ícone de ajuda.
+     *
+     * @return string HTML
+     */
     public function page_header()
     {
         $output = '';
@@ -46,6 +61,11 @@ class local_report_config_renderer extends plugin_renderer_base
         return $output;
     }
 
+    /**
+     * Rodapé da página.
+     *
+     * @return string HTML
+     */
     public function page_footer()
     {
         return $this->footer();

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -81,7 +81,13 @@ class local_report_config_locallib_testcase extends advanced_testcase {
         return array($category->id, $course->id, $assign->cmid, 'Atividade Elegivel');
     }
 
-    /** Nomes das atividades listadas por get_ordered_courses_activities para um curso. */
+    /**
+     * Nomes das atividades listadas por get_ordered_courses_activities para um curso.
+     *
+     * @param int $categoryid id da categoria
+     * @param int $courseid id do curso
+     * @return string[]
+     */
     private function listed_activity_names($categoryid, $courseid) {
         $result = get_ordered_courses_activities($categoryid);
         $names = array();


### PR DESCRIPTION
## Resumo

Completa a normalização para o `moodlecheck` adicionando **docblocks de classe, função e métodos** (com `@param`/`@return`) nos arquivos de produção. Complementa os cabeçalhos de arquivo já mergeados (PR #3).

## Arquivos
- `lib.php` — hook `local_report_config_extend_settings_navigation`, classe `Config` e métodos.
- `locallib.php` — `get_activities_courses`, `get_ordered_courses_activities`, `get_name_modulos`.
- `config_form.php` — classe `Config_form` e métodos.
- `renderer.php` — classe do renderer, métodos e declaração da propriedade `categoryid`.
- `db/upgrade.php` — função de upgrade.
- `tests/locallib_test.php` — completa o `@param` do helper `listed_activity_names`.

## Validação
- ✅ **`moodlecheck` (local_moodlecheck) executado contra o plugin: ZERO erros** em todos os arquivos (produção e testes).
- ✅ Todos os arquivos passam em `php -l`.
- **Sem mudança de comportamento**: apenas docblocks (+ declaração de uma propriedade já usada dinamicamente).

## Nota
Branch rebaseada sobre a `master` atual (já com PRs #2 e #3) — diff exclusivamente de docblocks, sem tocar no copyright (`2026 UFSC`).